### PR TITLE
Whenever the Console is resized, Windows reset the cursor. So we need…

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -147,6 +147,14 @@ namespace Terminal.Gui {
 			return false;
 		}
 
+		public void ForceRefreshCursorVisibility ()
+		{
+			if (currentCursorVisibility.HasValue) {
+				pendingCursorVisibility = currentCursorVisibility;
+				currentCursorVisibility = null;
+			}
+		}
+
 		public bool SetCursorVisibility (CursorVisibility visibility)
 		{
 			if (initialCursorVisibility.HasValue == false) {
@@ -1305,6 +1313,7 @@ namespace Terminal.Gui {
 				Bottom = (short)Rows,
 				Right = (short)Cols
 			};
+			winConsole.ForceRefreshCursorVisibility ();
 		}
 
 		void UpdateOffScreen ()


### PR DESCRIPTION
…  to reconfigure the cursor visibility.